### PR TITLE
Eコマース関連のRSSフィードを追加

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -72,4 +72,14 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['Zennの「LLM」のフィード', 'https://zenn.dev/topics/llm/feed'],
   ['LLMタグが付けられた新着記事 - Qiita', 'https://qiita.com/tags/llm/feed'],
   // ['「#LLM」の人気タグ記事一覧｜note ――つくる、つながる、とどける。', 'https://note.com/hashtag/LLM/rss'],
+
+  // Eコマース
+  ['Shopify Engineering', 'https://shopify.engineering/blog.atom'],
+  ['Shopify Blog', 'https://www.shopify.com/blog/feed'],
+  ['Practical Ecommerce', 'https://www.practicalecommerce.com/feed'],
+  ['Digital Commerce 360', 'https://www.digitalcommerce360.com/feed/'],
+  ['Ecommerce News Europe', 'https://ecommercenews.eu/feed/'],
+  ['Retail Dive', 'https://www.retaildive.com/feeds/news/'],
+  ['Baymard Institute', 'https://baymard.com/blog.atom'],
+  ['ECのミカタ', 'https://ecnomikata.com/rss/'],
 ]);

--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -82,4 +82,11 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['Retail Dive', 'https://www.retaildive.com/feeds/news/'],
   ['Baymard Institute', 'https://baymard.com/blog.atom'],
   ['ECのミカタ', 'https://ecnomikata.com/rss/'],
+  ['E-Commerce Times', 'https://www.ecommercetimes.com/rss-feed'],
+  ['WooCommerce Blog', 'https://woocommerce.com/blog/feed/'],
+  ['Stripe Blog', 'https://stripe.com/blog/feed.rss'],
+  ['Etsy Engineering (Code as Craft)', 'https://www.etsy.com/codeascraft/rss'],
+  ['ECzine', 'https://eczine.jp/rss/new/20/index.xml'],
+  ['ZOZO TECH BLOG', 'https://techblog.zozo.com/feed'],
+  ['BASEプロダクトチームブログ', 'https://devblog.thebase.in/feed'],
 ]);


### PR DESCRIPTION
## Summary

- Eコマース関連のRSSフィードを8件追加（海外6件・日本2件）
- 海外: Shopify Engineering, Shopify Blog, Practical Ecommerce, Digital Commerce 360, Ecommerce News Europe, Retail Dive, Baymard Institute
- 日本: ECのミカタ

## 追加フィード一覧

| ラベル | URL | 説明 |
|--------|-----|------|
| Shopify Engineering | shopify.engineering/blog.atom | Shopifyのエンジニアリングブログ |
| Shopify Blog | shopify.com/blog/feed | Shopify公式ブログ（EC運営tips） |
| Practical Ecommerce | practicalecommerce.com/feed | EC事業者向け独立系メディア |
| Digital Commerce 360 | digitalcommerce360.com/feed/ | EC業界ニュース・トレンド分析 |
| Ecommerce News Europe | ecommercenews.eu/feed/ | 欧州EC業界ニュース |
| Retail Dive | retaildive.com/feeds/news/ | 小売・EC業界ニュース |
| Baymard Institute | baymard.com/blog.atom | EC UX/UIリサーチ |
| ECのミカタ | ecnomikata.com/rss/ | 日本のEC・通販業界ニュース |

## Test plan
- [ ] ビルドが通ることを確認
- [ ] 追加したフィードURLが正しくRSS/Atomを返すことを確認
- [ ] ラベルが既存のものと重複していないことを確認

https://claude.ai/code/session_01Y6bRNUgS8AcdcAUDJBc44E