### PR TITLE
chore(feed): playpark (Zenn) 追加

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -60,7 +60,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['タイミー', 'https://tech.timee.co.jp/feed'],
   ['Socket', 'https://socket.dev/api/blog/feed.atom'],
   ['Cybozu Inside Out', 'https://blog.cybozu.io/rss'],
-  ['playpark | Zenn', 'https://zenn.dev/p/playpark/feed'],
+  ['playpark | Zenn', 'https://zenn.dev/playpark/feed'],
 
   // テックメディア
   ['WWW WATCH', 'https://feeds.feedburner.com/wacth'],

--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -60,6 +60,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['タイミー', 'https://tech.timee.co.jp/feed'],
   ['Socket', 'https://socket.dev/api/blog/feed.atom'],
   ['Cybozu Inside Out', 'https://blog.cybozu.io/rss'],
+  ['playpark | Zenn', 'https://zenn.dev/p/playpark/feed'],
 
   // テックメディア
   ['WWW WATCH', 'https://feeds.feedburner.com/wacth'],


### PR DESCRIPTION
## 概要

合同会社playpark のZenn Publication のテックブログフィードを追加します。

- 企業名: 合同会社playpark
- ブログURL: https://zenn.dev/playpark
- RSSフィードURL: https://zenn.dev/p/playpark/feed

Claude Code / Codex の比較、Claude Code Hooks × Skills、GEO 入門など、AI活用・Web開発に関する日本語の技術記事が中心の Publication です。

### 補足
実行環境のネットワーク制限により `zenn.dev` への到達が不可（`Host not in allowlist`）で、フィードの取得検証（external テスト）はこの環境では実施できていません。Zenn の Publication フィード仕様（`/p/<name>/feed`、既存の `ログラス (Zenn)` と同形式）に基づいた URL です。オフラインのバリデーション（lint / tsc / feed-info-list / feed-validator テスト）はすべて通過しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_018u35VtefdqfcvDFMW5NYSY)_