### PR TITLE
chore(feed): 取得できないフィードの整理（2ality/Shopify/ECzine）とクローラーUA修正

### DIFF
--- a/src/feed/feed-crawler.ts
+++ b/src/feed/feed-crawler.ts
@@ -124,7 +124,11 @@ export class FeedCrawler {
               logger.trace('[fetch-feed] cache hit', feedInfo.label, feedInfo.url);
               feedData = cachedData;
             } else {
-              const response = await fetch(feedInfo.url);
+              const response = await fetch(feedInfo.url, {
+                headers: {
+                  'user-agent': constants.requestUserAgent,
+                },
+              });
               if (!response.ok) {
                 throw new Error(`HTTP Error: ${response.status}`);
               }
@@ -211,7 +215,7 @@ export class FeedCrawler {
 
     // ブログごとの調整
     switch (feedInfo.label) {
-      case 'メルカリ':
+      case 'メルカリエンジニアリングブログ':
         // 9時間ずれているので調整
         FeedCrawler.subtractFeedItemsDateHour(customFeed, 9);
         customFeed.link = 'https://engineering.mercari.com/blog/';

--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -45,7 +45,8 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['OpenAI News', 'https://openai.com/news/rss.xml'],
   ['TECH BLOG | 株式会社AI Shift', 'https://www.ai-shift.co.jp/techblog/feed'],
   ['Platinum Data Blog by BrainPad ブレインパッド', 'https://blog.brainpad.co.jp/rss'],
-  ['メルカリエンジニアリングブログ', 'https://engineering.mercari.com/blog/feed.xml'],
+  // GitHub ActionsからのアクセスがWAFに403でブロックされるためコメントアウト（2026-07時点）
+  // ['メルカリエンジニアリングブログ', 'https://engineering.mercari.com/blog/feed.xml'],
   ['リクルートTech Blog', 'https://blog.recruit.co.jp/data/index.xml'],
   ['LINEヤフーTech Blog', 'https://techblog.lycorp.co.jp/ja/feed/index.xml'],
   ["NTT Communications Engineers' Blog", 'https://engineers.ntt.com/feed'],

--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -29,7 +29,8 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   // ['企業名・製品名など', 'RSS/AtomフィードのURL'],
 
   // 個人ブログ
-  ['2ality – JavaScript and more', 'https://2ality.com/feeds/posts.atom'],
+  // AIクローラー対策でサイト一時閉鎖中（2026-07時点）。復旧したら戻す
+  // ['2ality – JavaScript and more', 'https://2ality.com/feeds/posts.atom'],
   ['Stories by Kazuki Kyakuno on Medium', 'https://medium.com/feed/@kyakuno'],
   ['Mitsuyuki.Shiiba', 'https://bufferings.hatenablog.com/rss'],
   ['橋本商会', 'https://scrapbox.io/api/feed/shokai'],
@@ -76,8 +77,6 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   // ['「#LLM」の人気タグ記事一覧｜note ――つくる、つながる、とどける。', 'https://note.com/hashtag/LLM/rss'],
 
   // Eコマース
-  ['Shopify Engineering', 'https://shopify.engineering/blog.atom'],
-  ['Shopify Blog', 'https://www.shopify.com/blog/feed'],
   ['Practical Ecommerce', 'https://www.practicalecommerce.com/feed'],
   ['Digital Commerce 360', 'https://www.digitalcommerce360.com/feed/'],
   ['Ecommerce News Europe', 'https://ecommercenews.eu/feed/'],
@@ -88,7 +87,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['WooCommerce Blog', 'https://woocommerce.com/blog/feed/'],
   ['Stripe Blog', 'https://stripe.com/blog/feed.rss'],
   ['Etsy Engineering (Code as Craft)', 'https://www.etsy.com/codeascraft/rss'],
-  ['ECzine', 'https://eczine.jp/rss/new/20/index.xml'],
+  ['MarkeZine（CommerceZine）', 'https://markezine.jp/rss/new/20/index.xml'],
   ['ZOZO TECH BLOG', 'https://techblog.zozo.com/feed'],
   ['BASEプロダクトチームブログ', 'https://devblog.thebase.in/feed'],
 ]);


### PR DESCRIPTION
## 概要

GitHub Actions の feed-generate で恒常的に取得失敗していた5フィードを調査し、整理しました。

| フィード | 原因 | 対処 |
|---|---|---|
| 2ality | 404。作者がAIクローラー対策でサイト全体を一時閉鎖中（復旧は数ヶ月規模と告知） | コメントアウト（復旧したら戻す） |
| メルカリエンジニアリングブログ | 403。フィード自体は有効。Actions からのアクセスが WAF にブロック | コメントアウト（解消を確認できたら戻す） |
| Shopify Engineering | サイトリニューアルでフィード廃止（`blog.atom` は HTML を返す。`/latest.atom` `/rss.xml` 等も404） | 削除 |
| Shopify Blog | 404。代替パスも全滅 | 削除 |
| ECzine | 2026年6月に MarkeZine へ統合され「CommerceZine」に。旧RSSのリダイレクト先も404 | MarkeZine 総合フィードへ置き換え |

### 置き換えフィード
- MarkeZine（CommerceZine）
  - ブログURL: https://markezine.jp/commercezine/
  - RSSフィードURL: https://markezine.jp/rss/new/20/index.xml （有効性確認済み）

### クローラー修正
- フィード取得の `fetch()` が User-Agent 無しで送信されていたため、既存の `constants.requestUserAgent` を送るように修正（rss-parser・OG取得と同じUA）。メルカリの403がUA起因の場合の対策
- `postProcessFeed` の `case 'メルカリ'` が現ラベル「メルカリエンジニアリングブログ」と不一致で9時間の日付調整が効いていなかったのを修正（メルカリ復活時に有効）

### 検証
- `npm run lint` / `npm run test-internal` パス
- ローカルで `npm run feed-generate` 実行: 全フィード取得成功、`[fetch-feed] error` なし
- メルカリはUA修正で403が解消する可能性があるため、マージ後に `generate-feed.yml` の手動実行で確認し、解消していればコメントアウトを戻す

🤖 Generated with [Claude Code](https://claude.com/claude-code)