### PR TITLE
chore(feed): 趣味系（キーボード・ガジェット）フィードを watch-list-hobby-feed へ移動

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -109,16 +109,4 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['Latent Space', 'https://www.latent.space/feed'],
   ['Import AI (Jack Clark)', 'https://importai.substack.com/feed'],
   ['BAIR Blog (UC Berkeley)', 'https://bair.berkeley.edu/blog/feed.xml'],
-
-  // キーボード・ガジェット
-  ['自作キーボード温泉街の歩き方', 'https://salicylic-acid3.hatenablog.com/feed'],
-  ['遊舎工房 ニュース', 'https://shop.yushakobo.jp/blogs/news.atom'],
-  [
-    'Zennの「自作キーボード」のフィード',
-    'https://zenn.dev/topics/%E8%87%AA%E4%BD%9C%E3%82%AD%E3%83%BC%E3%83%9C%E3%83%BC%E3%83%89/feed',
-  ],
-  ['PC Watch', 'https://pc.watch.impress.co.jp/data/rss/1.0/pcw/feed.rdf'],
-  ['ギズモード・ジャパン', 'https://www.gizmodo.jp/index.xml'],
-  ['The Verge', 'https://www.theverge.com/rss/index.xml'],
-  ['Daily Gadget', 'https://daily-gadget.net/feed/'],
 ]);


### PR DESCRIPTION
## 概要

趣味系（キーボード・ガジェット）のフィード7件を、本リポジトリから watch-list-hobby-feed へ移動するため削除しました。

削除したフィード:
- 自作キーボード温泉街の歩き方 (https://salicylic-acid3.hatenablog.com/feed)
- 遊舎工房 ニュース (https://shop.yushakobo.jp/blogs/news.atom)
- Zennの「自作キーボード」のフィード (https://zenn.dev/topics/自作キーボード/feed)
- PC Watch (https://pc.watch.impress.co.jp/data/rss/1.0/pcw/feed.rdf)
- ギズモード・ジャパン (https://www.gizmodo.jp/index.xml)
- The Verge (https://www.theverge.com/rss/index.xml)
- Daily Gadget (https://daily-gadget.net/feed/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)